### PR TITLE
helpers for runtime parameters

### DIFF
--- a/mmif/serialize/view.py
+++ b/mmif/serialize/view.py
@@ -236,6 +236,13 @@ class ViewMetadata(FreezableMmifObject):
             self.contains[final_key] = new_contain
             return new_contain
 
+    def add_parameters(self, param_dict: dict = None, **param_kwargs):
+        if param_dict is None:
+            self.parameters = {}
+        else:
+            self.parameters = param_dict
+        self.parameters.update(dict(param_kwargs))
+
     def add_parameter(self, param_key, param_value):
         self.parameters[param_key] = param_value
 

--- a/mmif/serialize/view.py
+++ b/mmif/serialize/view.py
@@ -179,6 +179,7 @@ class ViewMetadata(FreezableMmifObject):
         self.timestamp: Optional[datetime] = None
         self.app: str = ''
         self.contains: ContainsDict = ContainsDict()
+        self.parameters: dict = {}
         self._required_attributes = pvector(["app", "contains"])
         super().__init__(viewmetadata_obj)
 
@@ -234,6 +235,15 @@ class ViewMetadata(FreezableMmifObject):
             new_contain = Contain(contain_dict)
             self.contains[final_key] = new_contain
             return new_contain
+
+    def add_parameter(self, param_key, param_value):
+        self.parameters[param_key] = param_value
+
+    def get_parameter(self, param_key):
+        try:
+            return self.parameters[param_key]
+        except KeyError:
+            raise KeyError(f"parameter \"{param_key}\" is not set in the view: {self.serialize()}")
 
 
 class Contain(FreezableMmifObject):

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -491,6 +491,15 @@ class TestView(unittest.TestCase):
         deserialized = ViewMetadata(serialized)
         self.assertEqual(vmeta, deserialized)
 
+    def test_view_parameters(self):
+        vmeta = ViewMetadata()
+        vmeta.add_parameter('pretty', False)
+        self.assertEqual(len(vmeta.parameters), 1)
+        print(vmeta.serialize(pretty=True))
+        self.assertEqual(vmeta.get_parameter('pretty'), False)
+        with pytest.raises(KeyError):
+            vmeta.get_parameter('not_exist')
+
     def test_props_preserved(self):
         view_serial = self.view_obj.serialize()
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -500,6 +500,13 @@ class TestView(unittest.TestCase):
         with pytest.raises(KeyError):
             vmeta.get_parameter('not_exist')
 
+    def test_view_parameters_batch_adding(self):
+        vmeta = ViewMetadata()
+        vmeta.add_parameters(pretty=True, validate=False)
+        self.assertEqual(len(vmeta.parameters), 2)
+        vmeta = ViewMetadata()
+        vmeta.add_parameters({'pretty': True, 'validate': False})
+
     def test_props_preserved(self):
         view_serial = self.view_obj.serialize()
 


### PR DESCRIPTION
This PR adds helpful methods to classes in serialize module to handle runtime parameters in the ViewMetadata. See clamsproject/mmif#154 and clamsproject/clams-python#29 for related discussion.

(Please ignore PR #149 and #147, as the repository wasn't properly configured for github actions when those were open) 