### PR TITLE
adding error field in the view metadata

### DIFF
--- a/mmif/serialize/annotation.py
+++ b/mmif/serialize/annotation.py
@@ -193,6 +193,10 @@ class DocumentProperties(AnnotationProperties):
         self.location_: str = ''
         self.text: Text = Text()
         self._attribute_classes = pmap({'text': Text})
+        # in theory, either `location` or `text` should appear in a `document`
+        # but with current implementation, there's no easy way to set a condition 
+        # for `oneOf` requirement 
+        # see MmifObject::_required_attributes in model.py 
         super().__init__(mmif_obj)
 
     def _deserialize(self, input_dict: dict) -> None:

--- a/mmif/serialize/mmif.py
+++ b/mmif/serialize/mmif.py
@@ -7,7 +7,7 @@ See the specification docs and the JSON Schema file for more information.
 
 import json
 from datetime import datetime
-from typing import List, Union, Optional, Dict, ClassVar, cast
+from typing import List, Union, Optional, Dict, ClassVar, cast, Generator
 
 import jsonschema.validators
 from pkg_resources import resource_stream
@@ -282,6 +282,10 @@ class Mmif(MmifObject):
             if len(alignments) > 0:
                 v_and_a[alignment_view.id] = alignments
         return v_and_a
+    
+    def get_latest_views(self) -> Generator[View, None, None]:
+        for view in sorted(self.views, key=lambda x: x.metadata.timestamp, reverse=True):
+            yield view
 
     def get_views_for_document(self, doc_id: str):
         """

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -13,7 +13,7 @@ from mmif import __specver__
 from mmif.serialize import *
 from mmif.vocabulary import DocumentTypes
 from mmif.serialize.model import *
-from mmif.serialize.view import ContainsDict
+from mmif.serialize.view import ContainsDict, ErrorDict
 from mmif.vocabulary import AnnotationTypes, DocumentTypes
 from pkg_resources import resource_stream
 from tests.mmif_examples import *
@@ -571,6 +571,22 @@ class TestView(unittest.TestCase):
         with pytest.raises(StopIteration):
             annotations = mmif_obj['v3'].get_annotations(AnnotationTypes.TimeFrame, unit='seconds')
             next(annotations)
+        
+    def test_errordict(self):
+        error = ErrorDict({"message": "some message", "stackTrace": "some trace"})
+        self.assertIsNotNone(error)
+        mmif_obj = Mmif(MMIF_EXAMPLES['mmif_example1'])
+        aview = mmif_obj.new_view()
+        ann = Annotation()
+        ann.id = 'a1'
+        aview.add_annotation(ann)
+        self.assertEqual(len(aview.annotations), 1)
+        aview.set_error("some message", "some trace")
+        self.assertEqual(len(aview.annotations), 0)
+        self.assertEqual(len(aview.metadata.contains), 0)
+        aview_json = json.loads(aview.serialize())
+        self.assertTrue("error" in aview_json['metadata'])
+        self.assertFalse("contains" in aview_json['metadata'])
 
 
 class TestAnnotation(unittest.TestCase):


### PR DESCRIPTION
This PR should not me merged until a new MMIF spec release that include https://github.com/clamsproject/mmif/pull/165 is available. 