### PR TITLE
added `warnings` field to `ViewMetadata` class

### DIFF
--- a/mmif/serialize/model.py
+++ b/mmif/serialize/model.py
@@ -333,7 +333,7 @@ class DataList(MmifObject, Generic[T]):
             mmif_obj = []
         super().__init__(mmif_obj)
 
-    def _serialize(self, *args, **kwargs) -> list:
+    def _serialize(self, *args, **kwargs) -> list:  # pytype: disable=signature-mismatch
         """
         Internal serialization method. Returns a list.
 

--- a/mmif/serialize/view.py
+++ b/mmif/serialize/view.py
@@ -240,6 +240,7 @@ class ViewMetadata(MmifObject):
         self.contains: ContainsDict = ContainsDict()
         self.parameters: dict = {}
         self.error: Union[dict, ErrorDict] = {}
+        self.warnings: List[str] = []
         self._required_attributes = ["app"]
         self._attribute_classes = {
             'error': ErrorDict,
@@ -282,6 +283,13 @@ class ViewMetadata(MmifObject):
     def set_error(self, message: str, stack_trace: str):
         self.error = ErrorDict({"message": message, "stackTrace": stack_trace})
         self.contains.empty()
+    
+    def add_warnings(self, *warnings: Warning):
+        for warning in warnings:
+            self.warnings.append(f'{warning.__class__.__name__}: {" - ".join(warning.args)}')
+
+    def emtpy_warnings(self):
+        self.warnings = []
 
 
 class ErrorDict(MmifObject):

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -4,9 +4,9 @@ import unittest
 from io import StringIO
 from unittest.mock import patch
 
-import hypothesis_jsonschema  # pip install hypothesis-jsonschema
+import hypothesis_jsonschema
 import pytest
-from hypothesis import given, settings, HealthCheck  # pip install hypothesis
+from hypothesis import given, settings, HealthCheck
 from jsonschema import ValidationError
 
 import mmif as mmifpkg
@@ -530,6 +530,16 @@ class TestView(unittest.TestCase):
         self.assertEqual(len(vmeta.parameters), 2)
         vmeta = ViewMetadata()
         vmeta.add_parameters(**{'pretty': True, 'validate': False})
+        
+    def test_add_warning(self):
+        vmeta = ViewMetadata()
+        w1 = Warning('first_warning')
+        w2 = UserWarning('second warning')
+        vmeta.add_warnings(w1, w2)
+        self.assertEqual(len(vmeta.warnings), 2)
+        for warning in vmeta.warnings:
+            self.assertTrue(isinstance(warning, str))
+            self.assertTrue('warning' in warning.lower())
 
     def test_props_preserved(self):
         view_serial = self.view_obj.serialize()


### PR DESCRIPTION
(Closes #201) 

As discussed in https://github.com/clamsproject/mmif/issues/188 and specified in https://github.com/clamsproject/mmif/pull/190, this PR adds APIs for the `warnings` field as a simple list of strings. 
