### PR TITLE
releasing 1.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,5 @@ distclean:
 	@rm -rf dist $(artifact) build/bdist*
 clean: distclean
 	@rm -rf VERSION VERSION.dev $(testcaches) $(buildcaches) $(generatedcode)
+	@git checkout -- documentation/target-versions.csv
+

--- a/setup.py
+++ b/setup.py
@@ -162,11 +162,17 @@ def generate_vocabulary(spec_version, clams_types_vers):
 
 
 def get_latest_mmif_gittag():
-    # vmaj, vmin, vpat = version.split('.')[0:3]
-    res = request.urlopen('https://api.github.com/repos/clamsproject/mmif/git/refs/tags')
-    body = json.loads(res.read())
-    tags = [os.path.basename(tag['ref']) for tag in body]
+    cur_p = 1
+    body = [None]
+    tags = []
+    while len(body) > 0:
+        # for when we have more than 30 (default pagination size) tags
+        res = request.urlopen(f'https://api.github.com/repos/clamsproject/mmif/tags?per_page=100&page={cur_p}')
+        body = json.loads(res.read())
+        tags.extend([tag['name'] for tag in body])
+        cur_p += 1
     # sort and return highest version
+    print(tags)
     mmif_ver_format = lambda x: re.match(r'\d+\.\d+\.\d$', x)
     return sorted([tag for tag in tags if mmif_ver_format(tag)])[-1]
 


### PR DESCRIPTION
### Overview
`mmif-python` 1.0.0 included MMIF 0.5.0 instead of  MMIF 1.0.0. This release fixes it

### Changes
* now based on MMIF specification 1.0.0