### PR TITLE
automatic generation of `Annotation` annotation 

### DIFF
--- a/mmif/__init__.py
+++ b/mmif/__init__.py
@@ -1,5 +1,3 @@
-import contextlib
-
 import pkg_resources
 
 from mmif.ver import __version__

--- a/mmif/serialize/annotation.py
+++ b/mmif/serialize/annotation.py
@@ -204,7 +204,7 @@ class Document(Annotation):
         if name == "text":
             self.properties.text = Text(value)
         elif name == "mime":
-            self.properties.mime = value
+            self.properties.mime = str(value)
         elif name == "location":
             self.location = value
         elif name not in self._props_original:

--- a/mmif/serialize/annotation.py
+++ b/mmif/serialize/annotation.py
@@ -165,6 +165,12 @@ class Document(Annotation):
         self.disallow_additional_properties()
         self._attribute_classes = {'properties': DocumentProperties}
         super().__init__(doc_obj)
+    
+    def _add_property_from_annotation(self, annotation: Annotation):
+        if annotation.at_type != AnnotationTypes.Annotation:
+            raise ValueError("Only `Annotation` type can be added as a property to a `Document` object.")
+        for prop_name, prop_value in annotation.properties.items():
+            self._props_existing[prop_name] = prop_value
 
     def add_property(self, name: str,
                      value: Union[JSON_PRMTV_TYPES, List[JSON_PRMTV_TYPES]]
@@ -220,6 +226,8 @@ class Document(Annotation):
         else:
             return super().get(prop_name)
 
+    get_property = get
+    
     @property
     def text_language(self) -> str:
         if self.at_type == DocumentTypes.TextDocument:

--- a/mmif/serialize/annotation.py
+++ b/mmif/serialize/annotation.py
@@ -38,6 +38,9 @@ class Annotation(MmifObject):
 
     def __init__(self, anno_obj: Optional[Union[bytes, str, dict]] = None) -> None:
         self._type: ThingTypesBase = ThingTypesBase('')
+        # to store the parent view ID
+        self._parent_view_id = ''
+        self.reserved_names.add('_parent_view_id')
         if not hasattr(self, 'properties'):  # don't overwrite DocumentProperties on super() call
             self.properties: AnnotationProperties = AnnotationProperties()
             self._attribute_classes = {'properties': AnnotationProperties}
@@ -69,6 +72,16 @@ class Annotation(MmifObject):
             self._type = ThingTypesBase.from_str(at_type)
         else:
             self._type = at_type
+
+    @property
+    def parent(self) -> str:
+        return self._parent_view_id
+
+    @parent.setter
+    def parent(self, parent_view_id: str) -> None:
+        # I want to make this to accept `View` object as an input too,
+        # but import `View` will break the code due to circular imports
+        self._parent_view_id = parent_view_id
 
     @property
     def id(self) -> str:
@@ -139,25 +152,12 @@ class Document(Annotation):
     :param document_obj: the JSON data that defines the document
     """
     def __init__(self, doc_obj: Optional[Union[bytes, str, dict]] = None) -> None:
-        # to store the parent view ID
-        self._parent_view_id = ''
-        self.reserved_names.add('_parent_view_id')
         
         self._type: Union[ThingTypesBase, DocumentTypesBase] = ThingTypesBase('')
         self.properties: DocumentProperties = DocumentProperties()
         self.disallow_additional_properties()
         self._attribute_classes = {'properties': DocumentProperties}
         super().__init__(doc_obj)
-
-    @property
-    def parent(self) -> str:
-        return self._parent_view_id
-
-    @parent.setter
-    def parent(self, parent_view_id: str) -> None:
-        # I want to make this to accept `View` object as an input too,
-        # but import `View` will break the code due to circular imports
-        self._parent_view_id = parent_view_id
 
     def add_property(self, name: str,
                      value: Union[JSON_COMPATIBLE_PRIMITIVES,

--- a/mmif/serialize/mmif.py
+++ b/mmif/serialize/mmif.py
@@ -570,7 +570,7 @@ class ViewsList(DataList[View]):
         """
         super()._append_with_key(value.id, value, overwrite)
 
-    def get_last(self) -> View:
+    def get_last(self) -> Optional[View]:
         """
         Returns the last view appended to the list.
         """

--- a/mmif/serialize/mmif.py
+++ b/mmif/serialize/mmif.py
@@ -447,6 +447,11 @@ class ViewsList(DataList[View]):
     for :class:`mmif.serialize.view.View`.
     """
     _items: Dict[str, View]
+    
+    def __init__(self, mmif_obj: Optional[Union[bytes, str, list]] = None):
+        self._last_view_id = None
+        self.reserved_names.add('_last_view_id')
+        super().__init__(mmif_obj)
 
     def _deserialize(self, input_list: list) -> None:  # pytype: disable=signature-mismatch
         """
@@ -456,7 +461,9 @@ class ViewsList(DataList[View]):
         :param input_list: the JSON data that defines the list of views
         :return: None
         """
-        self._items = {item['id']: View(item) for item in input_list}
+        if input_list:
+            self._items = {item['id']: View(item) for item in input_list}
+            self._last_view_id = input_list[-1]['id']
 
     def append(self, value: View, overwrite=False) -> None:
         """
@@ -474,4 +481,12 @@ class ViewsList(DataList[View]):
                           in the list
         :return: None
         """
+        self._last_view_id = value.id
         super()._append_with_key(value.id, value, overwrite)
+
+    def get_last(self) -> View:
+        """
+        Returns the last view appended to the list.
+        """
+        if self._last_view_id:
+            return self[self._last_view_id]

--- a/mmif/serialize/mmif.py
+++ b/mmif/serialize/mmif.py
@@ -195,9 +195,9 @@ class Mmif(MmifObject):
         docs = []
         for view in self.views:
             for doc in view.get_documents():
-                if prop_key in doc and doc.properties[prop_key] == prop_value:
+                if prop_key in doc and doc.get(prop_key) == prop_value:
                     docs.append(doc)
-        docs.extend([document for document in self.documents if document.properties[prop_key] == prop_value])
+        docs.extend([document for document in self.documents if document[prop_key] == prop_value])
         return docs
 
     def get_documents_locations(self, m_type: Union[DocumentTypes, str], path_only=False) -> List[Union[str, None]]:
@@ -279,7 +279,7 @@ class Mmif(MmifObject):
             else:
                 for alignment in alignment_view.get_annotations(AnnotationTypes.Alignment):
                     aligned_types = set()
-                    for ann_id in [alignment.properties['target'], alignment.properties['source']]:
+                    for ann_id in [alignment['target'], alignment['source']]:
                         ann_id = cast(str, ann_id)
                         if Mmif.id_delimiter in ann_id:
                             view_id, ann_id = ann_id.split(Mmif.id_delimiter)

--- a/mmif/serialize/model.py
+++ b/mmif/serialize/model.py
@@ -77,6 +77,8 @@ class MmifObject(object):
      an ID value automatically generated, based on its parent object.
     """
     
+    # these are the reserved names that cannot be used as attribute names, and 
+    # they won't be serialized
     reserved_names: Set[str] = {
         'reserved_names',
         '_unnamed_attributes',

--- a/mmif/serialize/model.py
+++ b/mmif/serialize/model.py
@@ -423,7 +423,7 @@ class DataList(MmifObject, Generic[T]):
         return self._items.__len__()
 
     def __reversed__(self) -> Iterator[T]:
-        return reversed(list(self._items.values()))
+        return reversed(self._items.values())
 
     def __contains__(self, item) -> bool:
         return item in self._items
@@ -443,9 +443,6 @@ class DataDict(MmifObject, Generic[T, S]):
 
     def _serialize(self, *args, **kwargs) -> dict:
         return super()._serialize(self._items)
-
-    def _deserialize(self, input_dict: dict) -> None:
-        raise NotImplementedError()
 
     def get(self, key: T, default=None) -> Optional[S]:
         return self._items.get(key, default)

--- a/mmif/serialize/model.py
+++ b/mmif/serialize/model.py
@@ -20,12 +20,14 @@ from deepdiff import DeepDiff
 
 T = TypeVar('T')
 S = TypeVar('S')
+JSON_PRMTV_TYPES: Type = Union[str, int, float, bool, None]
 
 __all__ = [
     'MmifObject',
     'MmifObjectEncoder',
     'DataList',
-    'DataDict'
+    'DataDict',
+    'JSON_PRMTV_TYPES'
 ]
 
 

--- a/mmif/serialize/view.py
+++ b/mmif/serialize/view.py
@@ -47,8 +47,7 @@ class View(MmifObject):
         self._required_attributes = ["id", "metadata", "annotations"]
         super().__init__(view_obj)
         for item in self.annotations:
-            if isinstance(item, Document):
-                item.parent = self.id
+            item.parent = self.id
 
     def new_contain(self, at_type: Union[str, ThingTypesBase], **contains_metadata) -> Optional['Contain']:
         """
@@ -116,6 +115,7 @@ class View(MmifObject):
                           in the view
         :return: the same Annotation object passed in as ``annotation``
         """
+        annotation.parent = self.id
         self.annotations.append(annotation, overwrite)
         self.new_contain(annotation.at_type)
         return annotation
@@ -162,7 +162,6 @@ class View(MmifObject):
                           an existing view with the same ID
         :return: None
         """
-        document.parent = self.id
         return self.add_annotation(document, overwrite)
 
     def get_annotations(self, at_type: Optional[Union[str, ThingTypesBase]] = None, 

--- a/mmif/serialize/view.py
+++ b/mmif/serialize/view.py
@@ -278,8 +278,11 @@ class ViewMetadata(MmifObject):
             
         if at_type not in self.contains:
             new_contain = Contain(contains_metadata)
-            self.contains[at_type] = new_contain
+            self.add_contain(new_contain, at_type)
             return new_contain
+    
+    def add_contain(self, contain: 'Contain', at_type: Union[str, ThingTypesBase]):
+        self.contains[at_type] = contain
 
     def add_parameters(self, **runtime_params):
         self.parameters.update(dict(runtime_params))

--- a/mmif/serialize/view.py
+++ b/mmif/serialize/view.py
@@ -317,7 +317,7 @@ class ErrorDict(MmifObject):
         super().__init__(error_obj)
         
 
-class Contain(MmifObject):
+class Contain(DataDict[str, str]):
     """
     Contain object that represents the metadata of a single
     annotation type in the ``contains`` metadata of a MMIF view.

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -845,6 +845,10 @@ class TestDocument(unittest.TestCase):
         ## after serialization, the `Annotation` annotation should be added to the last view
         mmif_roundtrip = Mmif(mmif.serialize())
         self.assertTrue(next(mmif_roundtrip.views.get_last().get_annotations(AnnotationTypes.Annotation, author='me')))
+        # finally, when deserialized back to a Mmif instance, the `Annotation` props should be added
+        # as a property of the document 
+        self.assertEqual('me', mmif_roundtrip.get_document_by_id('doc1').get_property('author'))
+    
     def test_deserialize_with_whole_mmif(self):
         for i, datum in self.data.items():
             for j, document in enumerate(datum['documents']):

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -610,7 +610,7 @@ class TestView(unittest.TestCase):
 
     def test_parent(self):
         mmif_obj = Mmif(self.mmif_examples_json['everything'])
-        self.assertTrue(all(doc.parent == v.id for v in mmif_obj.views for doc in mmif_obj.get_documents_in_view(v.id)))
+        self.assertTrue(all(anno.parent == v.id for v in mmif_obj.views for anno in mmif_obj.get_view_by_id(v.id).annotations))
 
     def test_get_by_id(self):
         mmif_obj = Mmif(MMIF_EXAMPLES['everything'])

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -171,7 +171,7 @@ class TestMmif(unittest.TestCase):
         mmif_obj = Mmif(MMIF_EXAMPLES['everything'])
         mmif_obj.add_document(Document(FRACTIONAL_EXAMPLES['doc_only']))
         self.assertEqual(len(mmif_obj.get_documents_by_property("mime", "video/mpeg")), 1)
-        self.assertEqual(len(mmif_obj.get_documents_by_property("mime", "text/plain")), 1)
+        self.assertEqual(len(mmif_obj.get_documents_by_property("mime", "text/plain")), 2)  # one from the original 'v4', one from the newly added here
 
     def test_get_documents_by_app(self):
         tesseract_appid = 'http://mmif.clams.ai/apps/tesseract/0.2.1'
@@ -740,6 +740,16 @@ class TestAnnotation(unittest.TestCase):
                                      f'Failed on {i}, {view_id}')
                 except ValidationError:
                     continue
+    
+    def test_get_property(self):
+        v = View()
+        a = v.new_annotation(AnnotationTypes.Annotation)
+        a.add_property('prop1', 'value1')
+        self.assertEqual(a.properties['prop1'], 'value1')
+        self.assertEqual(a['properties']['prop1'], 'value1')
+        self.assertEqual(a.get_property('prop1'), 'value1')
+        self.assertEqual(a['prop1'], 'value1')
+        self.assertEqual(a.id, a['id'])
 
     def test_id(self):
         anno_obj: Annotation = self.data['everything']['mmif']['v5:bb1']


### PR DESCRIPTION
fixes #226 . 

This PR adds SDK-level handling of document properties. See the linked issue for details. In the actual implementation, the property dicts in the proposal in the issue are renamed as follow: 

* `properties` -> `_props_original` : properties from the original `Document` object
* `properties2` -> `_props_temporary` : properties added during current app's run and will be "recorded" as `Annotation` annotation when processing is done and MMIf is serialized
* `properties3` -> `_props_existing` : properties found in previously existing `Annotation` annotations in previous views

