### PR TITLE
time unit conversion helper for ISO format in "gold" data in `aabp-annotations` repo

### DIFF
--- a/mmif/utils/timeunit_helper.py
+++ b/mmif/utils/timeunit_helper.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+from typing import Union
+
+
+UNIT_NORMALIZATION = {
+    'm': 'millisecond',
+    'ms': 'millisecond',
+    'msec': 'millisecond',
+    'millisecond': 'millisecond',
+    'milliseconds': 'millisecond',
+    's': 'second',
+    'se': 'second',
+    'sec': 'second',
+    'second': 'second',
+    'seconds': 'second',
+    'f': 'frame',
+    'fr': 'frame',
+    'frame': 'frame',
+    'frames': 'frame',
+    'i': 'isoformat',
+    'iso': 'isoformat',
+    'isoformat': 'isoformat',
+}
+
+
+def _isoformat_to_millisecond(isoformat: str) -> int:
+    t = datetime.strptime(isoformat, '%H:%M:%S.%f')
+    return int(1000 * (t.hour * 3600 + t.minute * 60 + t.second + t.microsecond / 1000000))
+
+
+def _millisecond_to_isoformat(millisecond: int) -> str:
+    t = datetime.utcfromtimestamp(millisecond / 1000)
+    return t.strftime('%H:%M:%S.%f')
+
+
+def _second_to_isoformat(second: float) -> str:
+    t = datetime.utcfromtimestamp(second)
+    return t.strftime('%H:%M:%S.%f')[:-3]  # python strftime will return "microsecond" with 6 digits
+
+
+def convert(t: Union[int, float, str], in_unit: str, out_unit: str, fps: float) -> Union[int, float, str]:
+    """
+    Converts time from one unit to another. Works with ``frames``, ``seconds``, ``milliseconds``.
+
+    :param t: time value to convert
+    :param in_unit: input time unit, one of ``frames``, ``seconds``, ``milliseconds``
+    :param out_unit: output time unit, one of ``frames``, ``seconds``, ``milliseconds``
+    :param fps: frames per second
+    :return: converted time value
+    """
+    try:
+        in_unit = UNIT_NORMALIZATION[in_unit]
+    except KeyError:
+        raise ValueError(f"Not supported time unit: {in_unit}")
+    try:
+        out_unit = UNIT_NORMALIZATION[out_unit]
+    except KeyError:
+        raise ValueError(f"Not supported time unit: {out_unit}")
+    if in_unit == 'isoformat':
+        if isinstance(t, str):
+            t = _isoformat_to_millisecond(t)
+            in_unit = 'millisecond'
+        else:
+            raise ValueError(f"Invalid time format: ISO format string expected, but got {t} of type {type(t)}")
+    # s>s, ms>ms, f>f
+    if in_unit == out_unit:
+        return t
+    elif out_unit == 'frame':
+        # ms>f
+        if 'millisecond' == in_unit:
+            return int(t / 1000 * fps)
+        # s>f
+        elif 'second' == in_unit:
+            return int(t * fps)
+    # s>(ms or i)
+    elif in_unit == 'second':
+        return t * 1000 if out_unit == 'millisecond' else _second_to_isoformat(t)
+    # ms>(s or i)
+    elif in_unit == 'millisecond':
+        return t / 1000 if out_unit == 'second' else _millisecond_to_isoformat(t)
+    # f>ms, f>s
+    else:
+        return (t / fps) if out_unit == 'second' else (t / fps * 1000)  # pytype: disable=bad-return-type
+

--- a/mmif/utils/video_document_helper.py
+++ b/mmif/utils/video_document_helper.py
@@ -4,6 +4,7 @@ from typing import List, Union, Tuple
 
 import mmif
 from mmif import Annotation, Document, Mmif
+from mmif.utils.timeunit_helper import convert
 from mmif.vocabulary import DocumentTypes
 
 for cv_dep in ('cv2', 'ffmpeg', 'PIL'):
@@ -19,23 +20,6 @@ FPS_DOCPROP_KEY = 'fps'
 FRAMECOUNT_DOCPROP_KEY = 'frameCount'
 DURATION_DOCPROP_KEY = 'duration'
 DURATIONUNIT_DOCPROP_KEY = 'durationTimeUnit'
-                           
-UNIT_NORMALIZATION = {
-    'm': 'millisecond',
-    'ms': 'millisecond',
-    'msec': 'millisecond',
-    'millisecond': 'millisecond',
-    'milliseconds': 'millisecond',
-    's': 'second',
-    'se': 'second',
-    'sec': 'second',
-    'second': 'second',
-    'seconds': 'second',
-    'f': 'frame',
-    'fr': 'frame',
-    'frame': 'frame',
-    'frames': 'frame',
-}
 
 
 def capture(video_document: Document):
@@ -155,45 +139,6 @@ def sample_frames(start_frame: int, end_frame: int, sample_ratio: int = 1) -> Li
     return frame_nums
 
 
-def convert(time: Union[int, float], in_unit: str, out_unit: str, fps: float) -> Union[int, float]:
-    """
-    Converts time from one unit to another. Works with ``frames``, ``seconds``, ``milliseconds``.
-
-    :param time: time value to convert
-    :param in_unit: input time unit, one of ``frames``, ``seconds``, ``milliseconds``
-    :param out_unit: output time unit, one of ``frames``, ``seconds``, ``milliseconds``
-    :param fps: frames per second
-    :return: converted time value
-    """
-    try:
-        in_unit = UNIT_NORMALIZATION[in_unit]
-    except KeyError:
-        raise ValueError(f"Not supported time unit: {in_unit}")
-    try:
-        out_unit = UNIT_NORMALIZATION[out_unit]
-    except KeyError:
-        raise ValueError(f"Not supported time unit: {out_unit}")
-    # s>s, ms>ms, f>f
-    if in_unit == out_unit:
-        return time
-    elif out_unit == 'frame':
-        # ms>f
-        if 'millisecond' == in_unit:
-            return int(time / 1000 * fps)
-        # s>f
-        elif 'second' == in_unit:
-            return int(time * fps)
-    # s>ms
-    elif in_unit == 'second':
-        return time * 1000
-    # ms>s
-    elif in_unit == 'millisecond':
-        return time // 1000
-    # f>ms, f>s
-    else:
-        return (time / fps) if out_unit == 'second' else (time / fps * 1000)  # pytype: disable=bad-return-type
-
-
 def get_annotation_property(mmif, annotation, prop_name):
     """
     .. deprecated:: 1.0.8
@@ -208,7 +153,7 @@ def get_annotation_property(mmif, annotation, prop_name):
     return annotation.get_property(prop_name)
 
 
-def convert_timepoint(mmif: Mmif, timepoint: Annotation, out_unit: str) -> Union[int, float]:
+def convert_timepoint(mmif: Mmif, timepoint: Annotation, out_unit: str) -> Union[int, float, str]:
     """
     Converts a time point included in an annotation to a different time unit.
     The input annotation must have ``timePoint`` property. 
@@ -223,7 +168,7 @@ def convert_timepoint(mmif: Mmif, timepoint: Annotation, out_unit: str) -> Union
     return convert(timepoint.get_property('timePoint'), in_unit, out_unit, get_framerate(vd))
 
 
-def convert_timeframe(mmif: Mmif, time_frame: Annotation, out_unit: str) -> Union[Tuple[int, int], Tuple[float, float]]:
+def convert_timeframe(mmif: Mmif, time_frame: Annotation, out_unit: str) -> Union[Tuple[Union[int, float, str], Union[int, float, str]]]:
     """
     Converts start and end points in a ``TimeFrame`` annotation a different time unit.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,23 @@
 import unittest
 
 from mmif import Mmif, Document, AnnotationTypes
+from mmif.utils import timeunit_helper as tuh
 from mmif.utils import video_document_helper as vdh
 
 
-class TestUtilsVideoDocuments(unittest.TestCase):
+class TestTimeunitHelper(unittest.TestCase):
+    
+    FPS = 30
+    
+    def test_convert(self):
+        self.assertEqual(1000, tuh.convert(1, 's', 'ms', self.FPS))
+        self.assertEqual(1.1, tuh.convert(1100, 'ms', 's', self.FPS))
+        self.assertEqual('00:01:30.000', tuh.convert(90, 's', 'i', self.FPS))
+        self.assertEqual(3300, tuh.convert('00:00:03.300', 'i', 'ms', self.FPS))
+        self.assertEqual(7.77, tuh.convert('00:00:07.770', 'i', 's', self.FPS))
+
+
+class TestVideoDocumentHelper(unittest.TestCase):
     def setUp(self):
         self.fps = 29.97
         self.mmif_obj = Mmif(validate=False)


### PR DESCRIPTION
fixes #258 . 