### PR TITLE
releasing 1.0.12

### DIFF
--- a/mmif/serialize/view.py
+++ b/mmif/serialize/view.py
@@ -245,7 +245,7 @@ class ViewMetadata(MmifObject):
         self.app: str = ''
         self.contains: ContainsDict = ContainsDict()
         self.parameters: Dict[str, str] = {}
-        self.app_configuration: Dict[str, Union[PRMTV_TYPES, List[PRMTV_TYPES]]] = {}
+        self.appConfiguration: Dict[str, Union[PRMTV_TYPES, List[PRMTV_TYPES]]] = {}
         self.error: Union[dict, ErrorDict] = {}
         self.warnings: List[str] = []
         self._required_attributes = ["app"]
@@ -291,14 +291,14 @@ class ViewMetadata(MmifObject):
         """
         Add a configuration key-value pair to the app_configuration dictionary.
         """
-        self.app_configuration[config_key] = config_value
+        self.appConfiguration[config_key] = config_value
 
     def get_app_configuration(self, config_key: str) -> Union[PRMTV_TYPES, List[PRMTV_TYPES]]:
         """
         Get a configuration value from the app_configuration dictionary.
         """
         try:
-            return self.app_configuration[config_key]
+            return self.appConfiguration[config_key]
         except KeyError:
             raise KeyError(f"app is not configured for \"{config_key}\" key in the view: {self.serialize()}")
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -610,7 +610,7 @@ class TestView(unittest.TestCase):
     def test_view_configuration(self):
         vmeta = ViewMetadata()
         vmeta.add_app_configuration('pretty', False)
-        self.assertEqual(len(vmeta.app_configuration), 1)
+        self.assertEqual(len(vmeta.appConfiguration), 1)
         self.assertEqual(vmeta.get_app_configuration('pretty'), False)
         with pytest.raises(KeyError):
             vmeta.get_app_configuration('not_exist')


### PR DESCRIPTION
### Overview
Hot-fixing a wrong field name. 

### Changes
- `views[].metadata.app_configuration` is renamed to `appConfiguration`, correctly following the MMIF json schema. 
