### PR TITLE
releasing 1.0.13

### DIFF
--- a/mmif/serialize/annotation.py
+++ b/mmif/serialize/annotation.py
@@ -26,7 +26,7 @@ __all__ = ['Annotation', 'AnnotationProperties', 'Document', 'DocumentProperties
 
 T = TypeVar('T')
 LIST_PRMTV = typing.List[PRMTV_TYPES]  # list of values (most cases for annotation props)
-LIST_LIST_PRMTV = typing.List[LIST_PRMTV]   # list of list of values (e.g. for coordinates)
+LIST_LIST_PRMTV = typing.List[LIST_PRMTV]   # list of lists of values (e.g. for coordinates)
 DICT_PRMTV = typing.Dict[str, PRMTV_TYPES]  # dict of values (`text` prop of `TextDocument` and other complex props)
 DICT_LIST_PRMTV = typing.Dict[str, LIST_PRMTV]  # dict of list of values (even more complex props)
 
@@ -127,6 +127,20 @@ class Annotation(MmifObject):
     def id(self, aid: str) -> None:
         self.properties.id = aid
         
+    @property
+    def long_id(self) -> str:
+        if self.parent is not None and len(self.parent) > 0:
+            return f"{self.parent}{self.id_delimiter}{self.id}"
+        else:
+            return self.id
+    
+    @long_id.setter
+    def long_id(self, long_id: str) -> None:
+        if self.id_delimiter in long_id:
+            self.parent, self.id = long_id.split(self.id_delimiter)
+        else:
+            self.id = long_id
+    
     @staticmethod
     def check_prop_value_is_simple_enough(
             value: Union[PRMTV_TYPES, LIST_PRMTV, LIST_LIST_PRMTV, DICT_PRMTV, DICT_LIST_PRMTV]) -> bool:

--- a/mmif/serialize/mmif.py
+++ b/mmif/serialize/mmif.py
@@ -10,13 +10,13 @@ import math
 import warnings
 from collections import defaultdict
 from datetime import datetime
-from typing import List, Union, Optional, Dict, ClassVar, cast
+from typing import List, Union, Optional, Dict, cast
 
 import jsonschema.validators
+
 import mmif
 from mmif import ThingTypesBase
 from mmif.vocabulary import AnnotationTypes, DocumentTypes
-
 from .annotation import Annotation, Document
 from .model import MmifObject, DataList
 from .view import View
@@ -31,9 +31,6 @@ class Mmif(MmifObject):
     :param mmif_obj: the JSON data
     :param validate: whether to validate the data against the MMIF JSON schema.
     """
-
-    view_prefix: ClassVar[str] = 'v_'
-    id_delimiter: ClassVar[str] = ':'
 
     def __init__(self, mmif_obj: Optional[Union[bytes, str, dict]] = None, *, validate: bool = True) -> None:
         self.metadata: MmifMetadata = MmifMetadata()
@@ -362,8 +359,8 @@ class Mmif(MmifObject):
         :return: a reference to the corresponding document, if it exists
         :raises KeyError: if there is no corresponding document
         """
-        if Mmif.id_delimiter in doc_id:
-            vid, did = doc_id.split(Mmif.id_delimiter)
+        if self.id_delimiter in doc_id:
+            vid, did = doc_id.split(self.id_delimiter)
             view = self[vid]
             if isinstance(view, View):
                 return view.get_document_by_id(did) 
@@ -410,8 +407,8 @@ class Mmif(MmifObject):
                     aligned_types = set()
                     for ann_id in [alignment['target'], alignment['source']]:
                         ann_id = cast(str, ann_id)
-                        if Mmif.id_delimiter in ann_id:
-                            view_id, ann_id = ann_id.split(Mmif.id_delimiter)
+                        if self.id_delimiter in ann_id:
+                            view_id, ann_id = ann_id.split(self.id_delimiter)
                             aligned_type = cast(Annotation, self[view_id][ann_id]).at_type
                         else:
                             aligned_type = cast(Annotation, alignment_view[ann_id]).at_type
@@ -438,8 +435,8 @@ class Mmif(MmifObject):
             except StopIteration:
                 # means search failed by the full doc_id string, 
                 # now try trimming the view_id from the string and re-do the search
-                if Mmif.id_delimiter in doc_id:
-                    vid, did = doc_id.split(Mmif.id_delimiter)
+                if self.id_delimiter in doc_id:
+                    vid, did = doc_id.split(self.id_delimiter)
                     if view.id == vid:
                         annotations = view.get_annotations(document=did)
                         try:
@@ -506,8 +503,8 @@ class Mmif(MmifObject):
         elif 'targets' in props:
             
             def get_target_ann(cur_ann, target_id):
-                if Mmif.id_delimiter not in target_id:
-                    target_id = Mmif.id_delimiter.join((cur_ann.parent, target_id))
+                if self.id_delimiter not in target_id:
+                    target_id = self.id_delimiter.join((cur_ann.parent, target_id))
                 return self.__getitem__(target_id)
             
             if not targets_sorted:
@@ -549,7 +546,7 @@ class Mmif(MmifObject):
         """
         if item in self._named_attributes():
             return self.__dict__[item]
-        split_attempt = item.split(Mmif.id_delimiter)
+        split_attempt = item.split(self.id_delimiter)
 
         document_result = self.documents.get(split_attempt[0])
         view_result = self.views.get(split_attempt[0])

--- a/mmif/serialize/model.py
+++ b/mmif/serialize/model.py
@@ -14,7 +14,7 @@ for the different components of MMIF is added in the subclasses.
 
 import json
 from datetime import datetime
-from typing import Union, Any, Dict, Optional, TypeVar, Generic, Generator, Iterator, Type, Set
+from typing import Union, Any, Dict, Optional, TypeVar, Generic, Generator, Iterator, Type, Set, ClassVar
 
 from deepdiff import DeepDiff
 
@@ -79,6 +79,9 @@ class MmifObject(object):
      an ID value automatically generated, based on its parent object.
     """
     
+    view_prefix: ClassVar[str] = 'v_'
+    id_delimiter: ClassVar[str] = ':'
+
     # these are the reserved names that cannot be used as attribute names, and 
     # they won't be serialized
     reserved_names: Set[str] = {

--- a/mmif/utils/timeunit_helper.py
+++ b/mmif/utils/timeunit_helper.py
@@ -68,17 +68,17 @@ def convert(t: Union[int, float, str], in_unit: str, out_unit: str, fps: float) 
     elif out_unit == 'frame':
         # ms>f
         if 'millisecond' == in_unit:
-            return int(t / 1000 * fps)
+            return round(t / 1000 * fps)
         # s>f
         elif 'second' == in_unit:
-            return int(t * fps)
+            return round(t * fps)
     # s>(ms or i)
     elif in_unit == 'second':
-        return int(t * 1000) if out_unit == 'millisecond' else _second_to_isoformat(t)
+        return round(t * 1000) if out_unit == 'millisecond' else _second_to_isoformat(t)
     # ms>(s or i)
     elif in_unit == 'millisecond':
         return t / 1000 if out_unit == 'second' else _millisecond_to_isoformat(t)
     # f>ms, f>s
     else:
-        return (t / fps) if out_unit == 'second' else (round(t / fps, 3) * 1000)  # pytype: disable=bad-return-type
+        return (t / fps) if out_unit == 'second' else round(round(t / fps, 3) * 1000)  # pytype: disable=bad-return-type
 

--- a/mmif/utils/video_document_helper.py
+++ b/mmif/utils/video_document_helper.py
@@ -1,6 +1,7 @@
 import importlib
 import warnings
 from typing import List, Union, Tuple
+import math
 
 import mmif
 from mmif import Annotation, Document, Mmif
@@ -124,22 +125,23 @@ def extract_mid_frame(mmif: Mmif, time_frame: Annotation, as_PIL: bool = False):
     return extract_frames_as_images(vd, [get_mid_framenum(mmif, time_frame)], as_PIL=as_PIL)[0]
 
 
-def sample_frames(start_frame: int, end_frame: int, sample_ratio: int = 1) -> List[int]:
+def sample_frames(start_frame: int, end_frame: int, sample_rate: float = 1) -> List[int]:
     """
     Helper function to sample frames from a time interval.
-    Can also be used as a "cutoff" function when used with ``start_frame==0`` and ``sample_ratio==1``.
+    Can also be used as a "cutoff" function when used with ``start_frame==0`` and ``sample_rate==1``.
     
     :param start_frame: start frame of the interval
     :param end_frame: end frame of the interval
-    :param sample_ratio: sample ratio (or step) to configure how often to take a frame, default is 1, meaning all consecutive frames are sampled
+    :param sample_rate: sampling rate (or step) to configure how often to take a frame, default is 1, meaning all consecutive frames are sampled
 
     """
-    sample_ratio = int(sample_ratio)
-    if sample_ratio < 1:
-        raise ValueError(f"Sample ratio must be greater than 1, but got {sample_ratio}")
+    if sample_rate < 1:
+        raise ValueError(f"Sample rate must be greater than 1, but got {sample_rate}")
     frame_nums: List[int] = []
-    for i in range(start_frame, end_frame, sample_ratio):
-        frame_nums.append(i)
+    cur_f = start_frame
+    while cur_f < end_frame:
+        frame_nums.append(math.ceil(cur_f))
+        cur_f += sample_rate
     return frame_nums
 
 

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -916,6 +916,11 @@ class TestDocument(unittest.TestCase):
         self.assertEqual(d.id, d.get_property('id'))
         self.assertEqual(d.location, d.get_property('location'))
         self.assertEqual('value1', d.get_property('prop1'))
+        d.long_id = 'v1:d1'
+        self.assertEqual('v1:d1', d.long_id)
+        self.assertEqual('v1', d.parent)
+        self.assertEqual('d1', d.id)
+
 
     def test_nontext_document(self):
         ad = Document()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,7 +58,15 @@ class TestVideoDocumentHelper(unittest.TestCase):
 
     def test_milliseconds_to_frames(self):
         self.assertAlmostEqual(100, vdh.millisecond_to_framenum(self.video_doc, 3337.0), places=0)
-    
+
+    def test_convert_roundtrip(self):
+        # ms for 1 frame
+        tolerance = 1000 / self.video_doc.get_property('fps')
+        for ms in [1000, 1234, 4321, 44444, 789789]:
+            m2f = vdh.millisecond_to_framenum(self.video_doc, ms)
+            m2f2m = vdh.framenum_to_millisecond(self.video_doc, m2f)
+            self.assertAlmostEqual(ms, m2f2m, delta=tolerance)
+
     def test_sample_frames(self):
         s_frame = vdh.second_to_framenum(self.video_doc, 3)
         e_frame = vdh.second_to_framenum(self.video_doc, 5.5)


### PR DESCRIPTION
### Overview
This version includes small, but helpful improvements.

### Changes
* `Annotation` object now has `long_id` property that returns the cross-view reference-ready ID in `view_id:annotation_id` form
* time unit conversion is now more stable (change of rounding)
* video frame sampling can now use fractional sampling rate (in terms of frame numbers)
