### PR TITLE
Rep frame helper

### DIFF
--- a/mmif/utils/video_document_helper.py
+++ b/mmif/utils/video_document_helper.py
@@ -6,7 +6,7 @@ import math
 import mmif
 from mmif import Annotation, Document, Mmif
 from mmif.utils.timeunit_helper import convert
-from mmif.vocabulary import DocumentTypes
+from mmif.vocabulary import DocumentTypes, AnnotationTypes
 
 for cv_dep in ('cv2', 'ffmpeg', 'PIL'):
     try:
@@ -141,7 +141,17 @@ def get_representative_framenum(mmif: Mmif, time_frame: Annotation):
     video_document = mmif[time_frame.get_property('document')]
     fps = get_framerate(video_document)
     representatives = time_frame.get_property('representatives')
-    representative_timepoint_anno = mmif.get_annotation(representatives[0])
+    top_representative_id = representatives[0]
+    views = mmif.get_all_views_contain(AnnotationTypes.TimePoint)
+    representative_timepoint_anno = None
+    for view in views:
+        try:
+            representative_timepoint_anno = view.get_annotation_by_id(top_representative_id)
+            break
+        except KeyError:
+            continue
+    if top_representative_id and not representative_timepoint_anno:
+        raise ValueError(f'Representative timepoint {top_representative_id} not found in any view.')
     return convert(representative_timepoint_anno.get_property('timePoint'), timeunit, 'frame', fps)
 
 

--- a/mmif/utils/video_document_helper.py
+++ b/mmif/utils/video_document_helper.py
@@ -142,15 +142,9 @@ def get_representative_framenum(mmif: Mmif, time_frame: Annotation):
     fps = get_framerate(video_document)
     representatives = time_frame.get_property('representatives')
     top_representative_id = representatives[0]
-    views = mmif.get_all_views_contain(AnnotationTypes.TimePoint)
-    representative_timepoint_anno = None
-    for view in views:
-        try:
-            representative_timepoint_anno = view.get_annotation_by_id(top_representative_id)
-            break
-        except KeyError:
-            continue
-    if not representative_timepoint_anno:
+    try:
+        representative_timepoint_anno = mmif[time_frame._parent_view_id+time_frame.id_delimiter+top_representative_id]
+    except KeyError:
         raise ValueError(f'Representative timepoint {top_representative_id} not found in any view.')
     return convert(representative_timepoint_anno.get_property('timePoint'), timeunit, 'frame', fps)
 

--- a/mmif/utils/video_document_helper.py
+++ b/mmif/utils/video_document_helper.py
@@ -150,7 +150,7 @@ def get_representative_framenum(mmif: Mmif, time_frame: Annotation):
             break
         except KeyError:
             continue
-    if top_representative_id and not representative_timepoint_anno:
+    if not representative_timepoint_anno:
         raise ValueError(f'Representative timepoint {top_representative_id} not found in any view.')
     return convert(representative_timepoint_anno.get_property('timePoint'), timeunit, 'frame', fps)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,7 +46,8 @@ class TestVideoDocumentHelper(unittest.TestCase):
 
     def test_extract_representative_frame(self):
         tp = self.a_view.new_annotation(AnnotationTypes.TimePoint, timePoint=1500, timeUnit='milliseconds', document='d1')
-        tf = self.a_view.new_annotation(AnnotationTypes.TimeFrame, start=1000, end=2000, timeUnit='milliseconds', document='d1', properties={'representatives': [tp.id]})
+        tf = self.a_view.new_annotation(AnnotationTypes.TimeFrame, start=1000, end=2000, timeUnit='milliseconds', document='d1')
+        tf.add_property('representatives', [tp.id])
         rep_frame_num = vdh.get_representative_framenum(self.mmif_obj, tf)
         expected_frame_num = vdh.millisecond_to_framenum(self.video_doc, tp.get_property('timePoint'))
         self.assertEqual(expected_frame_num, rep_frame_num)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,7 +57,6 @@ class TestVideoDocumentHelper(unittest.TestCase):
             vdh.get_representative_framenum(self.mmif_obj, tf)
         # check there is an error if there is a representative referencing a timepoint that
         # does not exist
-        tf = self.a_view.new_annotation(AnnotationTypes.TimeFrame, start=1000, end=2000, timeUnit='milliseconds', document='d1')
         tf.add_property('representatives', ['fake_tp_id'])
         with pytest.raises(ValueError):
             vdh.get_representative_framenum(self.mmif_obj, tf)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,6 +55,12 @@ class TestVideoDocumentHelper(unittest.TestCase):
         tf = self.a_view.new_annotation(AnnotationTypes.TimeFrame, start=1000, end=2000, timeUnit='milliseconds', document='d1')
         with pytest.raises(ValueError):
             vdh.get_representative_framenum(self.mmif_obj, tf)
+        # check there is an error if there is a representative referencing a timepoint that
+        # does not exist
+        tf = self.a_view.new_annotation(AnnotationTypes.TimeFrame, start=1000, end=2000, timeUnit='milliseconds', document='d1')
+        tf.add_property('representatives', ['fake_tp_id'])
+        with pytest.raises(ValueError):
+            vdh.get_representative_framenum(self.mmif_obj, tf)
 
     def test_get_framerate(self):
         self.assertAlmostEqual(29.97, vdh.get_framerate(self.video_doc), places=0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,6 +44,17 @@ class TestVideoDocumentHelper(unittest.TestCase):
         tf = self.a_view.new_annotation(AnnotationTypes.TimeFrame, start=0, end=3, timeUnit='seconds', document='d1')
         self.assertEqual(vdh.convert(1.5, 's', 'f', self.fps), vdh.get_mid_framenum(self.mmif_obj, tf))
 
+    def test_extract_representative_frame(self):
+        tp = self.a_view.new_annotation(AnnotationTypes.TimePoint, timePoint=1500, timeUnit='milliseconds', document='d1')
+        tf = self.a_view.new_annotation(AnnotationTypes.TimeFrame, start=1000, end=2000, timeUnit='milliseconds', document='d1', properties={'representatives': [tp.id]})
+        rep_frame_num = vdh.get_representative_framenum(self.mmif_obj, tf)
+        expected_frame_num = vdh.millisecond_to_framenum(self.video_doc, tp.get_property('timePoint'))
+        self.assertEqual(expected_frame_num, rep_frame_num)
+        # check there is an error if no representatives
+        tf = self.a_view.new_annotation(AnnotationTypes.TimeFrame, start=1000, end=2000, timeUnit='milliseconds', document='d1')
+        with pytest.raises(ValueError):
+            vdh.get_representative_framenum(self.mmif_obj, tf)
+
     def test_get_framerate(self):
         self.assertAlmostEqual(29.97, vdh.get_framerate(self.video_doc), places=0)
 


### PR DESCRIPTION
Adds two functions to `video_document_helper.py`. Functions are used to extract the image for the representative timepoint for a given timeframe annotation. 
