### PR TITLE
295-fix-pythonic-behavior

### DIFF
--- a/mmif/serialize/__init__.py
+++ b/mmif/serialize/__init__.py
@@ -1,3 +1,41 @@
+"""
+Aggregatitive summary for mmif.serialize package:
+
+''Prerequisites'': recall CLAMS MMIF structure at https://mmif.clams.ai/1.0.5/#the-structure-of-mmif-files
+
+The MMIF follows JSON schema which consists of two data structures: dictionary/hash and list.
+Therefore, for the purpose of best practice in Python's OOP, MMIF overwrites its own 'dict-like'
+and 'list-like' classes.
+
+As a high-level overview of the package, the following parent classes are defined first:
+
+- `MmifObject`: a base class for MMIF objects that are ''dict-like''
+- `DataList`: a base class for MMIF data fields that are ''list-like''
+- `DataDict`: a base class for MMIF data fields that are ''dict-like''
+
+Then, the following classes are defined and categorized into either ''dict-like''
+or ''list-like'' child classes:
+
+'''dict-like''':
+    - `Mmif`: a class for MMIF objects
+    - `MmifMetaData`: a class for MMIF metadata
+    - `View`: a class for MMIF view
+    - `ViewMetaData`: a class for MMIF view metadata
+    - `ErrorDict`: a class for a specific view that contains error
+    - `ContainsDict`: a class for `View`'s 'contains' field
+    - `Annotation` & `Document`: a class for MMIF annotation and document
+    - `AnnotationProperties` & `DocumentProperties`: a class for MMIF annotation properties
+    - `Text`: a class for `Document`'s text field
+
+'''list-like''':
+    - `DocumentsList`: a class for a list of `Document` objects
+    - `ViewsList`: a class for a list of `View` objects
+    - `AnnotationsList`: a class for a list of `Annotation` objects
+
+By doing so, the any field of a ''dict-like'' class should be accessed if and
+only if by either bracket `[key]` or `.get(key)`. For a ''list-like'' class, the
+elements are ordered and accessed by index, for example, `[idx]`.
+"""
 from .annotation import *
 from .annotation import __all__ as anno_all
 from .mmif import *

--- a/mmif/serialize/annotation.py
+++ b/mmif/serialize/annotation.py
@@ -259,11 +259,11 @@ class Annotation(MmifObject):
         is preferred.
         """
         if 'label' in self:
-            return str(self.get('label'))
+            return str(self.get_property('label'))
         elif self._type.shortname == 'TimeFrame' and 'frameType' in self:
-            return str(self.get('frameType'))
+            return str(self.get_property('frameType'))
         elif self._type.shortname == 'BoundingBox' and 'boxType' in self:
-            return str(self.get('boxType'))
+            return str(self.get_property('boxType'))
         else:
             raise KeyError("No label found in this annotation.")
 

--- a/mmif/serialize/view.py
+++ b/mmif/serialize/view.py
@@ -197,7 +197,7 @@ class View(MmifObject):
             except KeyError:
                 ann_found = None
         else:
-            ann_found = self.annotations.get(ann_id.split(self.id_delimiter)[-1])
+            ann_found = self.annotations.get_item(ann_id.split(self.id_delimiter)[-1])
         if ann_found is None or not isinstance(ann_found, Annotation):
             if self.id_delimiter in ann_id:
                 raise KeyError(f"Annotation \"{ann_id}\" is not found in the MMIF.")
@@ -210,7 +210,7 @@ class View(MmifObject):
         return [cast(Document, annotation) for annotation in self.annotations if annotation.is_document()]
 
     def get_document_by_id(self, doc_id) -> Document:
-        doc_found = self.annotations.get(doc_id)
+        doc_found = self.annotations.get_item(doc_id)
         if doc_found is None or not isinstance(doc_found, Document):
             raise KeyError(f"Document \"{doc_id}\" not found in view {self.id}.")
         else:
@@ -234,7 +234,7 @@ class View(MmifObject):
         """
         if key in self._named_attributes():
             return self.__dict__[key]
-        anno_result = self.annotations.get(key)
+        anno_result = self.annotations.get_item(key)
         if not anno_result:
             raise KeyError("Annotation ID not found: %s" % key)
         return anno_result
@@ -453,16 +453,6 @@ class AnnotationsList(DataList[Union[Annotation, Document]]):
         :return: None
         """
         super()._append_with_key(value.id, value, overwrite)
-
-    def __getitem__(self, key: str):
-        """
-        specialized getter implementation to workaround https://github.com/clamsproject/mmif/issues/228
-        # TODO (krim @ 7/12/24): annotation ids must be in the long form in the future, so this check will be unnecessary once https://github.com/clamsproject/mmif/issues/228 is resolved.
-        """
-        if ":" in key:
-            _, aid = key.split(":")
-            return self._items.__getitem__(aid)
-        return self._items.get(key, None)
 
 
 class ContainsDict(DataDict[ThingTypesBase, Contain]):


### PR DESCRIPTION
## Description
This PR aims to fix #295 which pointed out that dict-like (and list-like) classes in `mmif.serialize` package need to hold python's `dict` (and `list`) properties.

## Overview of classes in `mmif.serialize`

- `MmifObject`: a base class for MMIF objects that are ''dict-like''
- `DataList`: a base class for MMIF data fields that are ''list-like''
- `DataDict`: a base class for MMIF data fields that are ''dict-like''

Then, the following classes are defined and categorized into either ''dict-like''
or ''list-like'' child classes:

**dict-like**:
    - `Mmif`: a class for MMIF objects
    - `MmifMetaData`: a class for MMIF metadata
    - `View`: a class for MMIF view
    - `ViewMetaData`: a class for MMIF view metadata
    - `ErrorDict`: a class for a specific view that contains error
    - `ContainsDict`: a class for `View`'s 'contains' field
    - `Annotation` & `Document`: a class for MMIF annotation and document
    - `AnnotationProperties` & `DocumentProperties`: a class for MMIF annotation properties
    - `Text`: a class for `Document`'s text field

**list-like**:
    - `DocumentsList`: a class for a list of `Document` objects
    - `ViewsList`: a class for a list of `View` objects
    - `AnnotationsList`: a class for a list of `Annotation` objects

By doing so, any field of a ''dict-like'' class should be accessed if and
only if by either bracket `[key]` or `.get(key)`. For a ''list-like'' class, the
elements are ordered and accessed by index, for example, `[idx]`.

>[!NOTE]
As I discussed with @keighrim, we intentionally leave a "backdoor" method `get_item` for the abstract class `DataList` in order for achieving O(1) access to data (for example, a `View` or an `Annotation`) by its `long_id`.



