### PR TITLE
brought back "source" information as part of workflowId

### DIFF
--- a/mmif/utils/workflow_helper.py
+++ b/mmif/utils/workflow_helper.py
@@ -115,7 +115,11 @@ def generate_workflow_identifier(mmif_input: Union[str, Path, Mmif],
     Generate a workflow identifier string from a MMIF file or object.
 
     The identifier follows the storage directory structure format:
-    app_name/version/param_hash/app_name2/version2/param_hash2/...
+    source_composition/app_name/version/param_hash/app_name2/version2/param_hash2/...
+
+    The leading ``source_composition`` segment encodes the top-level
+    document mix as ``Type-N`` pairs joined by ``-`` and sorted by type
+    name (e.g. ``TextDocument-1-VideoDocument-1``).
 
     Uses view.metadata.parameters (raw user-passed values) for hashing
     to ensure reproducibility. Views with errors or warnings are excluded
@@ -127,6 +131,10 @@ def generate_workflow_identifier(mmif_input: Union[str, Path, Mmif],
     """
     data = _read_mmif_from_path(mmif_input)
     segments = []
+
+    # First prefix is source information, sorted by document type
+    sources = Counter(doc.at_type.shortname for doc in data.documents)
+    segments.append('-'.join([f'{k}-{sources[k]}' for k in sorted(sources.keys())]))
 
     # Group views into runs
     grouped_apps = group_views_by_app(data.views)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -471,9 +471,9 @@ class TestWorkflowHelper(unittest.TestCase):
         try:
             workflow_id = wfh.generate_workflow_identifier(tmp_file)
             segments = workflow_id.split('/')
-            self.assertEqual(len(segments), 6)
-            self.assertIn('app1', segments[0])
-            self.assertIn('app2', segments[3])
+            self.assertEqual(len(segments), 7)
+            self.assertIn('app1', segments[1])
+            self.assertIn('app2', segments[4])
         finally:
             os.unlink(tmp_file)
 


### PR DESCRIPTION
this reverts the decision at https://github.com/clamsproject/mmif-python/issues/326#issuecomment-3675345689 and brings back the "fix" proposed in https://github.com/clamsproject/mmif-python/issues/326#issuecomment-3584933104 . Also see https://github.com/clamsproject/aapb-brandeis-datahousing/issues/42 